### PR TITLE
Deprecate type `ReshapeVector`, use `Base.ReshapedArray` in src/Electrostatics.jl

### DIFF
--- a/src/Electrostatics.jl
+++ b/src/Electrostatics.jl
@@ -2,24 +2,7 @@ module Electrostatics
 
 using ..LastHomework: DiscreteLaplacian
 
-export ReshapeVector, getindices, checkequal, set!
-
-struct ReshapeVector{T} <: AbstractVector{T}
-    data::Vector{T}
-    size::NTuple{2,Int64}
-    function ReshapeVector{T}(data, size) where {T}
-        if length(data) != prod(size)
-            throw(
-                DimensionMismatch(
-                    "dimensions $size must be consistent with array size $(length(data))!"
-                ),
-            )
-        end
-        return new(data, size)
-    end
-end
-ReshapeVector(data::AbstractVector{T}, dims) where {T} = ReshapeVector{T}(data, dims)
-ReshapeVector(data::AbstractVector{T}, dims...) where {T} = ReshapeVector{T}(data, dims)
+export getindices, checkequal, set!
 
 abstract type FixedRegion end
 struct Boundary <: FixedRegion end
@@ -81,21 +64,6 @@ function set!(data::AbstractVecOrMat, value, region::FixedRegion)
     end
     return data
 end
-
-Base.parent(vec::ReshapeVector) = vec.data
-
-Base.size(vec::ReshapeVector) = size(parent(vec))
-
-Base.IndexStyle(::Type{ReshapeVector{T}}) where {T} = IndexLinear()
-
-Base.getindex(vec::ReshapeVector, i) = getindex(parent(vec), i)
-
-Base.setindex!(vec::ReshapeVector, v, i) = setindex!(parent(vec), v, i)
-
-# Base.similar(::ReshapeVector, ::Type{T}, dims::Dims) where {T} =
-#     ReshapeVector(Vector{T}(undef, dims), dims)
-
-Base.reshape(vec::ReshapeVector) = reshape(vec.data, vec.size)
 
 Base.parent(vec::PartiallyFixedVector) = vec.parent
 

--- a/src/Electrostatics.jl
+++ b/src/Electrostatics.jl
@@ -97,11 +97,11 @@ Base.setindex!(vec::ReshapeVector, v, i) = setindex!(parent(vec), v, i)
 
 Base.reshape(vec::ReshapeVector) = reshape(vec.data, vec.size)
 
-Base.parent(vec::PartiallyFixedVector) = vec.data
+Base.parent(vec::PartiallyFixedVector) = vec.parent
 
 Base.size(vec::PartiallyFixedVector) = size(parent(vec))
 
-Base.IndexStyle(::Type{PartiallyFixedVector{T}}) where {T} = IndexLinear()
+Base.IndexStyle(::Type{<:PartiallyFixedVector}) = IndexLinear()
 
 Base.getindex(vec::PartiallyFixedVector, i) = getindex(parent(vec), i)
 


### PR DESCRIPTION
I wanted to use `ReshapedArray`, but they are wrong in matrix-vector multiplication