### PR TITLE
Fix the `DiscreteLaplacian` generation function, Check whether a `DiscreteLaplacian` is positive definite

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -22,6 +22,8 @@ function DiscreteLaplacian(N::Integer)
     return DiscreteLaplacian(Symmetric(A))
 end
 
+leading_principal_minor(A::AbstractMatrix, k) = A[begin:k, begin:k]
+
 Base.parent(S::DiscreteLaplacian) = S.data
 
 Base.size(S::DiscreteLaplacian) = size(parent(S))

--- a/src/core.jl
+++ b/src/core.jl
@@ -17,11 +17,11 @@ struct DiscreteLaplacian <: AbstractSparseMatrix{Int64,Int64}
 end
 function DiscreteLaplacian(N::Integer)
     A = spdiagm(
-        0 => fill(-4, N^2),
-        1 => [mod(i, N) == N - 1 ? 0 : 1 for i in 0:(N^2 - 2)],
-        N - 1 => [mod(i, N) == 0 ? 1 : 0 for i in 0:(N^2 - N)],
-        N => fill(1, N^2 - N),
-        N^2 - N => fill(1, N),
+        0 => fill(4, N^2),
+        1 => [mod(i, N) == N - 1 ? 0 : -1 for i in 0:(N^2 - 2)],
+        N - 1 => [mod(i, N) == 0 ? -1 : 0 for i in 0:(N^2 - N)],
+        N => fill(-1, N^2 - N),
+        N^2 - N => fill(-1, N),
     )  # An upper triangular matrix
     return DiscreteLaplacian(Symmetric(A))
 end

--- a/src/core.jl
+++ b/src/core.jl
@@ -1,4 +1,4 @@
-using LinearAlgebra: Symmetric, issymmetric
+using LinearAlgebra: Symmetric, issymmetric, det
 using SparseArrays: AbstractSparseMatrix, SparseMatrixCSC, spdiagm
 
 export DiscreteLaplacian
@@ -8,6 +8,10 @@ struct DiscreteLaplacian <: AbstractSparseMatrix{Int64,Int64}
     function DiscreteLaplacian(data::AbstractMatrix)
         @assert issymmetric(data)
         @assert all(iszero(sum(data; dims=2)))
+        @assert all(
+            det(leading_principal_minor(data, k)) > zero(eltype(data)) for
+            k in axes(data, 1)[begin:(end - 1)]
+        )
         return new(data)
     end
 end


### PR DESCRIPTION
A Laplacian is [positive semidefinite](https://ocw.mit.edu/courses/18-409-topics-in-theoretical-computer-science-an-algorithmists-toolkit-fall-2009/7c5d4c779c64e9ed3a5783a80b7eb0a5_MIT18_409F09_scribe2.pdf).
For how to determine a matrix is positive definite, use [Sylvester’s criterion](https://en.wikipedia.org/wiki/Sylvester%27s_criterion)