### PR TITLE
Deprecate `PartiallyFixedMatrix` types & its interface

### DIFF
--- a/src/Electrostatics.jl
+++ b/src/Electrostatics.jl
@@ -75,4 +75,10 @@ function set(data, region::FixedValueRegion)
     return vec(data)
 end
 
+function Base.:*(A::DiscreteLaplacian, 𝐩ₙ::AbstractVector)
+    𝐩ₙ = set(𝐩ₙ, BOUNDARY)
+    𝐩ₙ = set(𝐩ₙ, SQUARE)
+    return parent(A) * parent(𝐩ₙ)
+end
+
 end

--- a/src/Electrostatics.jl
+++ b/src/Electrostatics.jl
@@ -22,8 +22,7 @@ struct PointCharges{T} <: FixedValueRegion{T}
     value::T
 end
 
-function getindices(ϕ, region::Boundary)
-    ϕ = reshape(ϕ, region.boxsize)
+function getindices(ϕ::AbstractMatrix, ::Boundary)
     cartesian_indices = CartesianIndices(ϕ)
     # Note the geometry of the region and the matrix rows/columns ordering are the same!
     # See https://discourse.julialang.org/t/how-to-get-the-cartesian-indices-of-a-row-column-in-a-matrix/91940/2
@@ -34,19 +33,25 @@ function getindices(ϕ, region::Boundary)
         cartesian_indices[:, end],  # Right
     )
 end
-function getindices(ϕ, region::InternalSquare)
-    M, N = region.boxsize .- 1
-    ϕ = reshape(ϕ, region.boxsize)
+function getindices(ϕ::AbstractMatrix, ::InternalSquare)
+    M, N = size(ϕ) .- 1
     xₘᵢₙ, xₘₐₓ, yₘᵢₙ, yₘₐₓ = map(Int64, (M / 2, M * 3//4, N * 5//8, N * 7//8))
     return map(Iterators.product(xₘᵢₙ:xₘₐₓ, yₘᵢₙ:yₘₐₓ)) do (i, j)
         CartesianIndex(j + 1, i + 1)   # Note y -> row, x -> column
     end
 end
-function getindices(ρ, region::PointCharges)
-    M, N = region.boxsize .- 1
-    ρ = reshape(ρ, region.boxsize)
+function getindices(ρ::AbstractMatrix, ::PointCharges)
+    M, N = size(ρ) .- 1
     x₁, x₂, y = map(Int64, (M / 4, M * 3//4, N / 8)) .+ 1
     return map(CartesianIndex, ((y, x₁), (y, x₂)))  # Note y -> row, x -> column
+end
+# See See https://discourse.julialang.org/t/how-to-convert-cartesianindex-n-values-to-int64/15074/4
+# and http://docs.julialang.org/en/v1/base/arrays/#Base.LinearIndices
+function getindices(vec::AbstractVector, region::FixedValueRegion)
+    mat = reshape(vec, region.boxsize)
+    linear_indices = LinearIndices(mat)
+    cartesian_indices = collect(getindices(mat, region))  # `getindex` only accepts vector indices
+    return linear_indices[cartesian_indices]
 end
 
 function checkequal(data::PartiallyFixedMatrix, region::FixedValueRegion)

--- a/src/Electrostatics.jl
+++ b/src/Electrostatics.jl
@@ -22,6 +22,11 @@ struct PointCharges{T} <: FixedValueRegion{T}
     value::T
 end
 
+N::Int64 = 33
+
+BOUNDARY = Boundary((N, N), 0)
+SQUARE = InternalSquare((N, N), 5)
+
 function getindices(ϕ::AbstractMatrix, ::Boundary)
     cartesian_indices = CartesianIndices(ϕ)
     # Note the geometry of the region and the matrix rows/columns ordering are the same!

--- a/src/Electrostatics.jl
+++ b/src/Electrostatics.jl
@@ -6,12 +6,19 @@ export Boundary, InternalSquare, PointCharges, getindices, checkequal, set!
 
 abstract type FixedValueRegion{T} end
 struct Boundary{T} <: FixedValueRegion{T}
+    boxsize::NTuple{2,Int}
     value::T
 end
 struct InternalSquare{T} <: FixedValueRegion{T}
+    boxsize::NTuple{2,Int}
+    value::T
+end
+struct PointCharge{T} <: FixedValueRegion{T}
+    boxsize::NTuple{2,Int}
     value::T
 end
 struct PointCharges{T} <: FixedValueRegion{T}
+    boxsize::NTuple{2,Int}
     value::T
 end
 

--- a/src/Electrostatics.jl
+++ b/src/Electrostatics.jl
@@ -54,7 +54,7 @@ function getindices(vec::AbstractVector, region::FixedValueRegion)
     return linear_indices[cartesian_indices]
 end
 
-function checkequal(data::PartiallyFixedMatrix, region::FixedValueRegion)
+function checkequal(data, region::FixedValueRegion)
     indices = getindices(data, region)
     for index in indices
         @assert data[index] == region.value

--- a/src/Electrostatics.jl
+++ b/src/Electrostatics.jl
@@ -2,14 +2,7 @@ module Electrostatics
 
 using ..LastHomework: DiscreteLaplacian
 
-export Boundary,
-    InternalSquare,
-    PointCharges,
-    SolutionMatrix,
-    ResidualMatrix,
-    getindices,
-    checkequal,
-    set!
+export Boundary, InternalSquare, PointCharges, getindices, checkequal, set!
 
 abstract type FixedValueRegion{T} end
 struct Boundary{T} <: FixedValueRegion{T}
@@ -20,14 +13,6 @@ struct InternalSquare{T} <: FixedValueRegion{T}
 end
 struct PointCharges{T} <: FixedValueRegion{T}
     value::T
-end
-
-abstract type PartiallyFixedMatrix{T} <: AbstractMatrix{T} end
-struct SolutionMatrix{T} <: PartiallyFixedMatrix{T}
-    parent::Matrix{T}
-end
-struct ResidualMatrix{T} <: PartiallyFixedMatrix{T}
-    parent::Matrix{T}
 end
 
 function getindices(ϕ::AbstractMatrix, ::Boundary)
@@ -67,38 +52,6 @@ function set!(data::PartiallyFixedMatrix, region::FixedValueRegion)
     for index in indices
         data[index] = region.value
     end
-    return data
-end
-
-Base.parent(data::PartiallyFixedMatrix) = data.parent
-
-Base.size(data::PartiallyFixedMatrix) = size(parent(data))
-
-Base.IndexStyle(::Type{<:PartiallyFixedMatrix}) = IndexLinear()
-
-Base.getindex(data::PartiallyFixedMatrix, i) = getindex(parent(data), i)
-
-Base.setindex!(data::PartiallyFixedMatrix, v, i) = setindex!(parent(data), v, i)
-
-for T in (:SolutionMatrix, :ResidualMatrix)
-    @eval begin
-        Base.similar(::$T, ::Type{S}, dims::Dims) where {S} = $T(Matrix{S}(undef, dims))
-    end
-end
-
-function Base.:*(A::DiscreteLaplacian, data::SolutionMatrix)
-    𝐯 = parent(A) * vec(parent(data))
-    data = SolutionMatrix(reshape(𝐯, size(data)))
-    set!(data, Boundary(0))
-    set!(data, InternalSquare(5))
-    return data
-end
-function Base.:*(A::DiscreteLaplacian, data::ResidualMatrix)
-    𝐯 = parent(A) * vec(parent(data))
-    data = ResidualMatrix(reshape(𝐯, size(data)))
-    set!(data, Boundary(0))
-    set!(data, InternalSquare(0))
-    set!(data, PointCharges(-20))
     return data
 end
 

--- a/src/Electrostatics.jl
+++ b/src/Electrostatics.jl
@@ -2,7 +2,7 @@ module Electrostatics
 
 using ..LastHomework: DiscreteLaplacian
 
-export Boundary, InternalSquare, PointCharges, getindices, checkequal, set!
+export Boundary, InternalSquare, PointCharges, getindices, checkequal, set
 
 abstract type FixedValueRegion{T} end
 struct Boundary{T} <: FixedValueRegion{T}
@@ -62,12 +62,12 @@ function checkequal(data::PartiallyFixedMatrix, region::FixedValueRegion)
     return nothing
 end
 
-function set!(data::PartiallyFixedMatrix, region::FixedValueRegion)
+function set(data, region::FixedValueRegion)
     indices = getindices(data, region)
     for index in indices
         data[index] = region.value
     end
-    return data
+    return vec(data)
 end
 
 end

--- a/src/Electrostatics.jl
+++ b/src/Electrostatics.jl
@@ -22,7 +22,8 @@ struct PointCharges{T} <: FixedValueRegion{T}
     value::T
 end
 
-function getindices(ϕ::AbstractMatrix, ::Boundary)
+function getindices(ϕ, region::Boundary)
+    ϕ = reshape(ϕ, region.boxsize)
     cartesian_indices = CartesianIndices(ϕ)
     # Note the geometry of the region and the matrix rows/columns ordering are the same!
     # See https://discourse.julialang.org/t/how-to-get-the-cartesian-indices-of-a-row-column-in-a-matrix/91940/2
@@ -33,16 +34,18 @@ function getindices(ϕ::AbstractMatrix, ::Boundary)
         cartesian_indices[:, end],  # Right
     )
 end
-function getindices(ϕ::AbstractMatrix, ::InternalSquare)
-    M, N = size(ϕ)
+function getindices(ϕ, region::InternalSquare)
+    M, N = region.boxsize .- 1
+    ϕ = reshape(ϕ, region.boxsize)
     xₘᵢₙ, xₘₐₓ, yₘᵢₙ, yₘₐₓ = map(Int64, (M / 2, M * 3//4, N * 5//8, N * 7//8))
     return map(Iterators.product(xₘᵢₙ:xₘₐₓ, yₘᵢₙ:yₘₐₓ)) do (i, j)
-        CartesianIndex(j, i)  # Note y -> row, x -> column
+        CartesianIndex(j + 1, i + 1)   # Note y -> row, x -> column
     end
 end
-function getindices(ρ::AbstractMatrix, ::PointCharges)
-    M, N = size(ρ)
-    x₁, x₂, y = map(Int64, (M / 4, M * 3//4, N / 8))
+function getindices(ρ, region::PointCharges)
+    M, N = region.boxsize .- 1
+    ρ = reshape(ρ, region.boxsize)
+    x₁, x₂, y = map(Int64, (M / 4, M * 3//4, N / 8)) .+ 1
     return map(CartesianIndex, ((y, x₁), (y, x₂)))  # Note y -> row, x -> column
 end
 


### PR DESCRIPTION
Recover `getindices` for `AbstractVector` & `AbstractMatrix` (Looks like #13, which was deprecated in #14)